### PR TITLE
[AQS-4490] Fix G+ social share feature

### DIFF
--- a/lib/webpack/assets/version.rb
+++ b/lib/webpack/assets/version.rb
@@ -1,5 +1,5 @@
 module Webpack
   module Assets
-    VERSION = '0.2.1'
+    VERSION = '0.3.0'
   end
 end

--- a/lib/webpack/view_helpers.rb
+++ b/lib/webpack/view_helpers.rb
@@ -48,7 +48,7 @@ module Webpack
         else
           static_file = Webpack.fetch_static_file("#{Webpack.config.static_path}/#{path}")
           if Webpack.config.cdn_host.present?
-            "//#{Webpack.config.cdn_host}#{static_file}"
+            "#{protocol}#{Webpack.config.cdn_host}#{static_file}"
           else
             static_file
           end
@@ -57,8 +57,12 @@ module Webpack
 
       private
 
+      def protocol
+        @view_context.request.protocol.presence || '//'
+      end
+
       def server_url(path)
-        "//#{server_host}#{Webpack.config.public_path}/#{path}"
+        "#{protocol}#{server_host}#{Webpack.config.public_path}/#{path}"
       end
 
       def server_host

--- a/spec/webpack/view_helpers_spec.rb
+++ b/spec/webpack/view_helpers_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Webpack::ViewHelpers, type: :helper do
 
     it 'uses assets server url in development' do
       Webpack.config.use_server = true
-      is_expected.to include('"//test.host:4242/foobar/app.js"')
+      is_expected.to include('src="http://test.host:4242/foobar/app.js"')
     end
 
     it 'uses config.host' do
@@ -38,7 +38,7 @@ RSpec.describe Webpack::ViewHelpers, type: :helper do
 
     it 'uses precompiled path' do
       Webpack.config.use_server = false
-      is_expected.to include('"/foobar/baz.42.js"')
+      is_expected.to include('src="/foobar/baz.42.js"')
     end
   end
 
@@ -58,7 +58,7 @@ RSpec.describe Webpack::ViewHelpers, type: :helper do
 
     it 'uses precompiled path' do
       Webpack.config.use_server = false
-      is_expected.to include('"/foobar/baz.12.css"')
+      is_expected.to include('href="/foobar/baz.12.css"')
     end
 
     it 'does not render css tag when extract_css is false' do
@@ -72,7 +72,7 @@ RSpec.describe Webpack::ViewHelpers, type: :helper do
 
     it 'uses assets server url in development' do
       Webpack.config.use_server = true
-      is_expected.to eq('//test.host:4242/foobar/logo.png')
+      is_expected.to eq('http://test.host:4242/foobar/logo.png')
     end
 
     it 'uses config.host' do
@@ -86,9 +86,16 @@ RSpec.describe Webpack::ViewHelpers, type: :helper do
       is_expected.to eq('/foobar/42.png')
     end
 
+    it 'uses the request protocol' do
+      allow(helper.request).to receive(:protocol).and_return('https://')
+      Webpack.config.use_server = true
+      is_expected.to eq('https://test.host:4242/foobar/logo.png')
+    end
+
     it 'uses CDN host' do
+      Webpack.config.use_server = false
       Webpack.config.cdn_host = 'test.io'
-      is_expected.to eq('//test.io/foobar/42.png')
+      is_expected.to eq('http://test.io/foobar/42.png')
     end
   end
 end


### PR DESCRIPTION
[PLAT-4490](https://youtrack.toptal.net/youtrack/issue/PLAT-4490)

G+ social share feature wasn't working as expected, because we didn't provide schema (`http`/`https`) to the `og:image` URL value.

Now propagating the protocol from request.