### PR TITLE
support cdn_host for js/css

### DIFF
--- a/lib/webpack/view_helpers.rb
+++ b/lib/webpack/view_helpers.rb
@@ -38,7 +38,12 @@ module Webpack
         if Webpack.config.use_server
           server_url("#{name}.#{ext}")
         else
-          Webpack.fetch_entry(name.to_s, ext.to_s)
+          entry = Webpack.fetch_entry(name.to_s, ext.to_s)
+          if Webpack.config.cdn_host.present?
+            "#{protocol}#{Webpack.config.cdn_host}#{entry}"
+          else
+            entry
+          end
         end
       end
 

--- a/spec/webpack/view_helpers_spec.rb
+++ b/spec/webpack/view_helpers_spec.rb
@@ -40,6 +40,26 @@ RSpec.describe Webpack::ViewHelpers, type: :helper do
       Webpack.config.use_server = false
       is_expected.to include('src="/foobar/baz.42.js"')
     end
+
+    it 'uses config.protocol' do
+      Webpack.config.protocol = 'https'
+      Webpack.config.use_server = true
+      Webpack.config.host = 'example.com:4040'
+      is_expected.to include('https://example.com:4040/foobar/app.js')
+    end
+
+    it 'uses the request protocol' do
+      allow(helper.request).to receive(:protocol).and_return('https://')
+      Webpack.config.use_server = true
+      is_expected.to include('https://test.host:4242/foobar/app.js')
+    end
+
+    it 'uses CDN host' do
+      Webpack.config.protocol = 'http'
+      Webpack.config.use_server = false
+      Webpack.config.cdn_host = 'test.io'
+      is_expected.to include('http://test.io/foobar/baz.42.js')
+    end
   end
 
   describe '#webpack_css_tag' do
@@ -58,12 +78,33 @@ RSpec.describe Webpack::ViewHelpers, type: :helper do
 
     it 'uses precompiled path' do
       Webpack.config.use_server = false
+      Webpack.config.cdn_host = nil
       is_expected.to include('href="/foobar/baz.12.css"')
     end
 
     it 'does not render css tag when extract_css is false' do
       Webpack.config.extract_css = false
       is_expected.to be_nil
+    end
+
+    it 'uses config.protocol' do
+      Webpack.config.protocol = 'https'
+      Webpack.config.use_server = true
+      Webpack.config.host = 'example.com:4040'
+      is_expected.to include('https://example.com:4040/foobar/app.css')
+    end
+
+    it 'uses the request protocol' do
+      allow(helper.request).to receive(:protocol).and_return('https://')
+      Webpack.config.use_server = true
+      is_expected.to include('https://test.host:4242/foobar/app.css')
+    end
+
+    it 'uses CDN host' do
+      Webpack.config.protocol = 'http'
+      Webpack.config.use_server = false
+      Webpack.config.cdn_host = 'test.io'
+      is_expected.to include('http://test.io/foobar/baz.12.css')
     end
   end
 
@@ -83,6 +124,7 @@ RSpec.describe Webpack::ViewHelpers, type: :helper do
 
     it 'uses precompiled path' do
       Webpack.config.use_server = false
+      Webpack.config.cdn_host = nil
       is_expected.to eq('/foobar/42.png')
     end
 


### PR DESCRIPTION
Support for `cdn_host` for both javascript and css.