### PR TITLE
Use CDN for all entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Optional settings:
 
 - `host` - the host with the port webpack dev server is running on (can be used instead of `port` option).
 
+- `cdn_host` - the CDN host (will be prepended to URLs for all files).
+
   Example usage:
 
   ```ruby
@@ -60,8 +62,6 @@ Optional settings:
     end
   end
   ```
-
-- `cdn_host` - the CDN host (used only in `webpack_static_file_url` for now).
 
 View helpers:
 

--- a/lib/webpack.rb
+++ b/lib/webpack.rb
@@ -20,6 +20,10 @@ module Webpack
       config.validate!
     end
 
+    def reset
+      @config = nil
+    end
+
     # @param entries [Hash]
     def load_entries(entries)
       @entries = entries

--- a/lib/webpack/assets/version.rb
+++ b/lib/webpack/assets/version.rb
@@ -1,5 +1,5 @@
 module Webpack
   module Assets
-    VERSION = '0.3.1'
+    VERSION = '0.3.2'
   end
 end

--- a/lib/webpack/view_helpers.rb
+++ b/lib/webpack/view_helpers.rb
@@ -38,7 +38,8 @@ module Webpack
         if Webpack.config.use_server
           server_url("#{name}.#{ext}")
         else
-          Webpack.fetch_entry(name.to_s, ext.to_s)
+          entry = Webpack.fetch_entry(name.to_s, ext.to_s)
+          full_url(entry)
         end
       end
 
@@ -47,15 +48,19 @@ module Webpack
           server_url(path)
         else
           static_file = Webpack.fetch_static_file("#{Webpack.config.static_path}/#{path}")
-          if Webpack.config.cdn_host.present?
-            "#{protocol}#{Webpack.config.cdn_host}#{static_file}"
-          else
-            static_file
-          end
+          full_url(static_file)
         end
       end
 
       private
+
+      def full_url(path)
+        if Webpack.config.cdn_host.present?
+          [protocol, Webpack.config.cdn_host, path].join
+        else
+          path
+        end
+      end
 
       def server_url(path)
         "#{protocol}#{server_host}#{Webpack.config.public_path}/#{path}"

--- a/spec/webpack/view_helpers_spec.rb
+++ b/spec/webpack/view_helpers_spec.rb
@@ -22,6 +22,10 @@ RSpec.describe Webpack::ViewHelpers, type: :helper do
     )
   end
 
+  after do
+    Webpack.reset
+  end
+
   describe '#webpack_js_tag' do
     subject { helper.webpack_js_tag(:app) }
 
@@ -39,6 +43,13 @@ RSpec.describe Webpack::ViewHelpers, type: :helper do
     it 'uses precompiled path' do
       Webpack.config.use_server = false
       is_expected.to include('src="/foobar/baz.42.js"')
+    end
+
+    it 'uses CDN host' do
+      Webpack.config.protocol = 'http'
+      Webpack.config.use_server = false
+      Webpack.config.cdn_host = 'test.io'
+      is_expected.to include('src="http://test.io/foobar/baz.42.js"')
     end
   end
 
@@ -64,6 +75,13 @@ RSpec.describe Webpack::ViewHelpers, type: :helper do
     it 'does not render css tag when extract_css is false' do
       Webpack.config.extract_css = false
       is_expected.to be_nil
+    end
+
+    it 'uses CDN host' do
+      Webpack.config.protocol = 'http'
+      Webpack.config.use_server = false
+      Webpack.config.cdn_host = 'test.io'
+      is_expected.to include('href="http://test.io/foobar/baz.12.css"')
     end
   end
 


### PR DESCRIPTION
Initially CDN option was used only for static files, which is not ideal.
With this patch if the option is set it will be used for every file
used by the application.